### PR TITLE
Added rudimentary domain whitelisting

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -12,7 +12,11 @@
     "description": "Title of the settings window."
   },
   "settingsEnableDescription": {
-    "message": "Enable Map Replace for all pages",
+    "message": "Enable Map Replace",
+    "description": "Description text for checkbox to enable Map Replace"
+  },
+  "settingsWhitelistDescription": {
+    "message": "Domain whitelist (ex: *.domain.com)",
     "description": "Description text for checkbox to enable Map Replace"
   },
   "refreshNotice": {

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -12,7 +12,11 @@
     "description": "Title of the settings window."
   },
   "settingsEnableDescription": {
-    "message": "Aktiver Map Replace på alle nettsider",
+    "message": "Aktiver Map Replace",
+    "description": "Description text for checkbox to enable Map Replace"
+  },
+  "settingsWhitelistDescription": {
+    "message": "Domene-hviteliste (eks: *.domene.no)",
     "description": "Description text for checkbox to enable Map Replace"
   },
   "refreshNotice": {

--- a/css/popup.css
+++ b/css/popup.css
@@ -7,7 +7,7 @@ body {
   background: url(../img/background.png);
   margin: 12px;
   min-width: 350px;
-  min-height: 500px;
+  min-height: 550px;
   font-family: Helvetica, Arial, sans-serif;
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,7 @@
     "default_popup": "src/browser_action/browser_action.html"
   },
   "permissions": [
+    "tabs",
     "webRequest",
     "webRequestBlocking",
     "storage",

--- a/src/browser_action/browser_action.js
+++ b/src/browser_action/browser_action.js
@@ -1,6 +1,7 @@
 ;(function (chrome, interceptors) {
   var settings = {
-    enabled: false
+    enabled: false,
+    whitelist: ["*"]
   };
 
   var populate = function () {
@@ -8,7 +9,8 @@
         locale = chrome.i18n.getMessage("@@ui_locale").substr(0, 2);
 
     $body.append("<h1>" + chrome.i18n.getMessage("settingsTitle") + "</h1>")
-         .append("<label><input type='checkbox' id='isEnabled' />" + chrome.i18n.getMessage("settingsEnableDescription") + "</label>");
+         .append("<label><input type='checkbox' id='isEnabled' />" + chrome.i18n.getMessage("settingsEnableDescription") + "</label>")
+         .append("<label for='whitelist'>" + chrome.i18n.getMessage("settingsWhitelistDescription") + "<textarea id='whitelist' rows=5 cols=40>" + settings.whitelist.join("\n") + "</textarea></label>");
 
     $.each(interceptors, function (interceptorId, interceptor) {
       $body.append("<h2>" + (interceptor.name[locale] || interceptor.name["en"]) + "</h2>");
@@ -60,14 +62,22 @@
     saveSettings();
   });
 
+  $("textarea#whitelist").bind('input propertychange', function () {
+    settings.whitelist = $("textarea#whitelist").val().split("\n");
+    saveSettings();
+  });
+
   chrome.storage.sync.get("mapSettings", function (storedSettings) {
     var mapSettings = storedSettings.mapSettings;
     settings.maptype = mapSettings.maptype;
     settings.layertype = mapSettings.layertype;
     settings.enabled = mapSettings.enabled;
+    settings.whitelist = mapSettings.whitelist;
 
     var checkedAttr = settings.enabled ? "checked" : null;
-    $("input[type='checkbox']").attr("checked", checkedAttr);
+    $("input#isEnabled").attr("checked", checkedAttr);
+    $("textarea#whitelist").val(settings.whitelist.join("\n"));
+
     $("input[data-layertype='" + mapSettings.layertype + "']").attr("checked", "checked");
     enableDisableSelection();
   });


### PR DESCRIPTION
A small feature allowing MapReplace to be applied only on selected domains.

Example whitelist:

```
*.no
runkeeper.com
*.runkeeper.com
```
