### PR TITLE
Recognize the new URL format used by Google Maps.

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -24,15 +24,24 @@
 
   var getMapInputs = function (url) {
     var matches = /lyrs=([^&]+)(?:.*)&x=([^&]*)(?:.*)&y=([^&]*)(?:.*)&z=([^&]*)/.exec(url);
-    if (!matches || matches.length < 4) {
-      return void 0;
+    if (matches && matches.length >= 5) {
+      return {
+        x: matches[2],
+        y: matches[3],
+        z: matches[4]
+      };
     }
 
-    return {
-      x: matches[2],
-      y: matches[3],
-      z: matches[4]
-    };
+    matches = /pb=[^&]*!1i(\d+)!2i(\d+)!3i(\d+)/.exec(url);
+    if (matches) {
+      return {
+        x: matches[2],
+        y: matches[3],
+        z: matches[1]
+      };
+    }
+
+    return void 0;
   };
 
   chrome.webRequest.onBeforeRequest.addListener(


### PR DESCRIPTION
The zoom level and the x and y coordinates seem to be encoded in a
different way these days. This patch makes the extension recognize the
new URL format as well as the old format.
